### PR TITLE
upgrade toolchain to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhth/outtasync
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5


### PR DESCRIPTION
## Summary
- upgrade the Go toolchain from 1.26.1 to 1.26.2